### PR TITLE
S3 object parameter and bucket deletion exclusive

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3.py
+++ b/lib/ansible/modules/cloud/amazon/s3.py
@@ -510,6 +510,10 @@ def main():
 
     if module.params.get('object'):
         obj = module.params['object']
+    
+    # Bucket deletion does not require obj param.  Prevents ambiguity with delobj.
+    if obj and mode == "delete":
+        module.fail_json(msg='Parameter obj cannot be used with mode=delete')
 
     # allow eucarc environment variables to be used if ansible vars aren't set
     if not s3_url and 'S3_URL' in os.environ:


### PR DESCRIPTION
Prevent users from deleting buckets rather than objects by making object parameter and mode=delobj mutually exclusive in task.
https://github.com/ansible/ansible/issues/21796

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
s3

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Addresses ansible#21796.  Prevent users from deleting buckets rather than objects by making ``object`` param and ``mode=delobj`` mutually exclusive.

